### PR TITLE
Correct sample glob

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ engines:
             urna eget libero fermentum bibendum. Duis dapibus, neque vel aliquet
             tincidunt, diam eros tempor neque
           path_patterns:
-            - "**.rb"
+            - "**/*.rb"
 ```
 
 `patterns` is a list of match configurations. Each key in it is an issue's check

--- a/lib/cc/engine/grep.rb
+++ b/lib/cc/engine/grep.rb
@@ -42,6 +42,9 @@ module CC
             io: io,
           ).run
         end
+      rescue ScannerConfig::InvalidConfigError => e
+        $stderr.puts e.message
+        exit 1
       rescue => e
         $stderr.puts e.message
       end


### PR DESCRIPTION
Derived from https://github.com/codeclimate/codeclimate-grep/pull/3

Just `**` doesn't descend into directories, you need the `**/*`.