### PR TITLE
Tweak example pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ a message.
 
 Example config:
 
-```
+```yaml
 engines:
   grep:
     enabled: true
     config:
       patterns:
         no-set-methods:
-          pattern: "def set_\\w+"
+          pattern: def set_\w+
           annotation: "Don't define methods that start with `set_`"
           severity: minor
           categories: Bug Risk


### PR DESCRIPTION
We can remove the extra backslash if we don't quote the pattern