### PR TITLE
Add option to change the type of regexp used

### DIFF
--- a/lib/cc/engine/scanner.rb
+++ b/lib/cc/engine/scanner.rb
@@ -40,8 +40,8 @@ module CC
       def grep_command(path)
         [
           "grep",
+          config.regexp_option,
           "--color=always", # Highlight matches
-          "--extended-regexp",
           "--with-filename", "--line-number",
           "--binary-files=without-match",
           "--no-messages",

--- a/lib/cc/engine/scanner.rb
+++ b/lib/cc/engine/scanner.rb
@@ -40,7 +40,7 @@ module CC
       def grep_command(path)
         [
           "grep",
-          config.regexp_option,
+          config.matcher_option,
           "--color=always", # Highlight matches
           "--with-filename", "--line-number",
           "--binary-files=without-match",

--- a/lib/cc/engine/scanner_config.rb
+++ b/lib/cc/engine/scanner_config.rb
@@ -14,7 +14,7 @@ module CC
         "basic" => "--basic-regexp",
         "extended" => "--extended-regexp",
         "perl" => "--perl-regexp",
-      }
+      }.freeze
 
       DEFAULT_MATCHER = "extended"
 

--- a/lib/cc/engine/scanner_config.rb
+++ b/lib/cc/engine/scanner_config.rb
@@ -9,14 +9,14 @@ module CC
       ].freeze
       SEVERITIES = %w[info minor major critical blocker].freeze
 
-      REGEXP_OPTIONS = {
+      MATCHER_OPTIONS = {
         "fixed" => "--fixed-strings",
         "basic" => "--basic-regexp",
         "extended" => "--extended-regexp",
         "perl" => "--perl-regexp",
       }
 
-      DEFAULT_REGEXP = "extended"
+      DEFAULT_MATCHER = "extended"
 
       class InvalidConfigError < StandardError; end
 
@@ -51,11 +51,11 @@ module CC
         config["content"]
       end
 
-      def regexp_option
-        regexp = config.fetch("regexp", DEFAULT_REGEXP)
+      def matcher_option
+        matcher = config.fetch("matcher", DEFAULT_MATCHER)
 
-        REGEXP_OPTIONS.fetch(regexp) do
-          raise InvalidConfigError, %(Invalid regexp "#{regexp}" for #{check_name}. Must be one of the following: #{REGEXP_OPTIONS.keys.join ", "})
+        MATCHER_OPTIONS.fetch(matcher) do
+          raise InvalidConfigError, %(Invalid matcher "#{matcher}" for #{check_name}. Must be one of the following: #{MATCHER_OPTIONS.keys.join ", "})
         end
       end
 
@@ -67,7 +67,7 @@ module CC
         validate_required_config_entries!
         validate_severity!
         validate_categories!
-        validate_regexp!
+        validate_matcher!
       end
 
       def validate_required_config_entries!
@@ -93,9 +93,9 @@ module CC
         end
       end
 
-      def validate_regexp!
+      def validate_matcher!
         # Option access validates, so just call eagerly
-        regexp_option
+        matcher_option
       end
     end
   end

--- a/lib/cc/engine/scanner_config.rb
+++ b/lib/cc/engine/scanner_config.rb
@@ -9,6 +9,15 @@ module CC
       ].freeze
       SEVERITIES = %w[info minor major critical blocker].freeze
 
+      REGEXP_OPTIONS = {
+        "fixed" => "--fixed-strings",
+        "basic" => "--basic-regexp",
+        "extended" => "--extended-regexp",
+        "perl" => "--perl-regexp",
+      }
+
+      DEFAULT_REGEXP = "extended"
+
       class InvalidConfigError < StandardError; end
 
       def initialize(config, check_name)
@@ -42,6 +51,14 @@ module CC
         config["content"]
       end
 
+      def regexp_option
+        regexp = config.fetch("regexp", DEFAULT_REGEXP)
+
+        REGEXP_OPTIONS.fetch(regexp) do
+          raise InvalidConfigError, %(Invalid regexp "#{regexp}" for #{check_name}. Must be one of the following: #{REGEXP_OPTIONS.keys.join ", "})
+        end
+      end
+
       private
 
       attr_reader :config, :check_name
@@ -50,6 +67,7 @@ module CC
         validate_required_config_entries!
         validate_severity!
         validate_categories!
+        validate_regexp!
       end
 
       def validate_required_config_entries!
@@ -73,6 +91,11 @@ module CC
             raise InvalidConfigError, %(Invalid category "#{category}" for #{check_name}. Must be one of the following: #{CATEGORIES.join ", "})
           end
         end
+      end
+
+      def validate_regexp!
+        # Option access validates, so just call eagerly
+        regexp_option
       end
     end
   end

--- a/spec/cc/engine/scanner_config_spec.rb
+++ b/spec/cc/engine/scanner_config_spec.rb
@@ -47,17 +47,17 @@ RSpec.describe CC::Engine::ScannerConfig do
     end.to raise_error(described_class::InvalidConfigError, %(Invalid category "Invasion" for invalid-category. Must be one of the following: Bug Risk, Clarity, Compatibility, Complexity, Duplication, Performance, Security, Style))
   end
 
-  it "validates regexp" do
+  it "validates matcher" do
     expect do
       described_class.new(
         {
           "pattern" => "ack",
           "annotation" => "Ack-Ack!!!",
-          "regexp" => "madeup"
+          "matcher" => "madeup"
         },
-        "invalid-regexp",
+        "invalid-matcher",
       )
-    end.to raise_error(described_class::InvalidConfigError, %(Invalid regexp "madeup" for invalid-regexp. Must be one of the following: fixed, basic, extended, perl))
+    end.to raise_error(described_class::InvalidConfigError, %(Invalid matcher "madeup" for invalid-matcher. Must be one of the following: fixed, basic, extended, perl))
   end
 
   it "defaults severity to minor" do
@@ -82,14 +82,14 @@ RSpec.describe CC::Engine::ScannerConfig do
     expect(config.categories).to eq ["Bug Risk"]
   end
 
-  it "defaults regexp to extended" do
+  it "defaults matcher to extended" do
     config = described_class.new(
       {
         "pattern" => "test",
         "annotation" => "Found it!",
       },
-      "default-regexp"
+      "default-matcher"
     )
-    expect(config.regexp_option).to eq "--extended-regexp"
+    expect(config.matcher_option).to eq "--extended-regexp"
   end
 end

--- a/spec/cc/engine/scanner_config_spec.rb
+++ b/spec/cc/engine/scanner_config_spec.rb
@@ -47,6 +47,19 @@ RSpec.describe CC::Engine::ScannerConfig do
     end.to raise_error(described_class::InvalidConfigError, %(Invalid category "Invasion" for invalid-category. Must be one of the following: Bug Risk, Clarity, Compatibility, Complexity, Duplication, Performance, Security, Style))
   end
 
+  it "validates regexp" do
+    expect do
+      described_class.new(
+        {
+          "pattern" => "ack",
+          "annotation" => "Ack-Ack!!!",
+          "regexp" => "madeup"
+        },
+        "invalid-regexp",
+      )
+    end.to raise_error(described_class::InvalidConfigError, %(Invalid regexp "madeup" for invalid-regexp. Must be one of the following: fixed, basic, extended, perl))
+  end
+
   it "defaults severity to minor" do
     config = described_class.new(
       {
@@ -67,5 +80,16 @@ RSpec.describe CC::Engine::ScannerConfig do
       "default-categories",
     )
     expect(config.categories).to eq ["Bug Risk"]
+  end
+
+  it "defaults regexp to extended" do
+    config = described_class.new(
+      {
+        "pattern" => "test",
+        "annotation" => "Found it!",
+      },
+      "default-regexp"
+    )
+    expect(config.regexp_option).to eq "--extended-regexp"
   end
 end

--- a/spec/cc/engine/scanner_spec.rb
+++ b/spec/cc/engine/scanner_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe CC::Engine::Scanner do
     scanner = described_class.new(
       check_name: "test-match",
       config: {
-        "regexp" => "perl",
+        "matcher" => "perl",
         "pattern" => "^match me(?! not here)",
         "annotation" => "Found it!"
       },
@@ -114,7 +114,7 @@ RSpec.describe CC::Engine::Scanner do
     scanner = described_class.new(
       check_name: "test-match",
       config: {
-        "regexp" => "basic",
+        "matcher" => "basic",
         "pattern" => "cat\\|dog",
         "annotation" => "Found it!"
       },
@@ -134,7 +134,7 @@ RSpec.describe CC::Engine::Scanner do
     scanner = described_class.new(
       check_name: "test-match",
       config: {
-        "regexp" => "fixed",
+        "matcher" => "fixed",
         "pattern" => "cat|dog",
         "annotation" => "Found it!"
       },

--- a/spec/cc/engine/scanner_spec.rb
+++ b/spec/cc/engine/scanner_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe CC::Engine::Scanner do
     expect(io.string).to eq ""
   end
 
-  it "understands extended regular expressions" do
+  it "understands extended regular expressions by default" do
     write_test_file "cat or dog"
     io = StringIO.new
     scanner = described_class.new(
@@ -86,6 +86,65 @@ RSpec.describe CC::Engine::Scanner do
 
     expect(io.string).to include %({"type":"issue","check_name":"test-match","description":"Found it!","categories":["Bug Risk"],"location":{"path":"test.txt","positions":{"begin":{"line":1,"column":1},"end":{"line":1,"column":4}}},"severity":"minor"}\n\u0000)
     expect(io.string).to include %({"type":"issue","check_name":"test-match","description":"Found it!","categories":["Bug Risk"],"location":{"path":"test.txt","positions":{"begin":{"line":1,"column":8},"end":{"line":1,"column":11}}},"severity":"minor"}\n\u0000)
+  end
+
+  it "can be configured for perl regular expressions" do
+    write_test_file "match me\nmatch me not here"
+    io = StringIO.new
+    scanner = described_class.new(
+      check_name: "test-match",
+      config: {
+        "regexp" => "perl",
+        "pattern" => "^match me(?! not here)",
+        "annotation" => "Found it!"
+      },
+      paths: ["test.txt"],
+      io: io
+    )
+
+    scanner.run
+
+    expect(io.string).to include %({"type":"issue","check_name":"test-match","description":"Found it!","categories":["Bug Risk"],"location":{"path":"test.txt","positions":{"begin":{"line":1,"column":1},"end":{"line":1,"column":9}}},"severity":"minor"}\n\u0000)
+    expect(io.string).not_to include %({"type":"issue","check_name":"test-match","description":"Found it!","categories":["Bug Risk"],"location":{"path":"test.txt","positions":{"begin":{"line":2,"column":9},"end":{"line":2,"column":9}}},"severity":"minor"}\n\u0000)
+  end
+
+  it "can be configured for basic matches" do
+    write_test_file "cat or dog"
+    io = StringIO.new
+    scanner = described_class.new(
+      check_name: "test-match",
+      config: {
+        "regexp" => "basic",
+        "pattern" => "cat\\|dog",
+        "annotation" => "Found it!"
+      },
+      paths: ["test.txt"],
+      io: io
+    )
+
+    scanner.run
+
+    expect(io.string).to include %({"type":"issue","check_name":"test-match","description":"Found it!","categories":["Bug Risk"],"location":{"path":"test.txt","positions":{"begin":{"line":1,"column":1},"end":{"line":1,"column":4}}},"severity":"minor"}\n\u0000)
+    expect(io.string).to include %({"type":"issue","check_name":"test-match","description":"Found it!","categories":["Bug Risk"],"location":{"path":"test.txt","positions":{"begin":{"line":1,"column":8},"end":{"line":1,"column":11}}},"severity":"minor"}\n\u0000)
+  end
+
+  it "can be configured for \"fixed string\" matches" do
+    write_test_file "cat|dog"
+    io = StringIO.new
+    scanner = described_class.new(
+      check_name: "test-match",
+      config: {
+        "regexp" => "fixed",
+        "pattern" => "cat|dog",
+        "annotation" => "Found it!"
+      },
+      paths: ["test.txt"],
+      io: io
+    )
+
+    scanner.run
+
+    expect(io.string).to include %({"type":"issue","check_name":"test-match","description":"Found it!","categories":["Bug Risk"],"location":{"path":"test.txt","positions":{"begin":{"line":1,"column":1},"end":{"line":1,"column":8}}},"severity":"minor"}\n\u0000)
   end
 
   it "includes content when available" do


### PR DESCRIPTION
Extends the configuration with a `regexp` key that supports `fixed|basic|extended|perl` as values. These map to the `grep` options that enable each kind of regexp. See _Matcher Selection_ in [grep(1)](https://linux.die.net/man/1/grep) for more details. (I didn't realize the docs called this "Matcher" until just now, so maybe `matcher` would be a better name?)

The default is `extended` to maintain the behavior from before this change. I find that odd, since `basic` is `grep`'s own default, but I don't think we can change it now.

Implements #18.