### PR TITLE
QUA-958: Push images to Dockerhub instead of GCR (beta)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,49 @@
+version: 2
+
+jobs:
+  test:
+    machine:
+      docker_layer_caching: true
+    working_directory: ~/codeclimate/codeclimate-grep
+    steps:
+      - checkout
+      - run: make image
+      - run: make test
+
+  release_images:
+    machine:
+      docker_layer_caching: true
+    working_directory: ~/codeclimate/codeclimate-grep
+    steps:
+      - checkout
+      - run:
+          name: Validate owner
+          command: |
+            if [ "$CIRCLE_PROJECT_USERNAME" -ne "codeclimate" ]
+            then
+              echo "Skipping release for non-codeclimate branches"
+              circleci step halt
+            fi
+      - run: make image
+      - run: echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+      - run:
+          name: Push image to Dockerhub
+          command: |
+            make release RELEASE_TAG="b$CIRCLE_BUILD_NUM"
+            make release RELEASE_TAG="$(echo $CIRCLE_BRANCH | grep -oP 'channel/\K[\w\-]+')"
+
+workflows:
+  version: 2
+  build_deploy:
+    jobs:
+      - test
+      - release_images:
+          context: Quality
+          requires:
+            - test
+          filters:
+            branches:
+              only: /master|channel\/[\w-]+/
+notify:
+  webhooks:
+    - url: https://cc-slack-proxy.herokuapp.com/circle

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,15 @@
 .PHONY: image test
 
 IMAGE_NAME ?= codeclimate/codeclimate-grep
+RELEASE_REGISTRY ?= codeclimate
+RELEASE_TAG ?= latest
 
 image:
 	docker build --rm -t $(IMAGE_NAME) .
 
 test: image
 	docker run --rm --workdir /usr/src/app $(IMAGE_NAME) sh -c "rspec"
+
+release:
+	docker tag $(IMAGE_NAME) $(RELEASE_REGISTRY)/codeclimate-grep:$(RELEASE_TAG)
+	docker push $(RELEASE_REGISTRY)/codeclimate-grep:$(RELEASE_TAG)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: image test
+.PHONY: image test release
 
 IMAGE_NAME ?= codeclimate/codeclimate-grep
 RELEASE_REGISTRY ?= codeclimate

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,10 @@
 
 IMAGE_NAME ?= codeclimate/codeclimate-grep
 RELEASE_REGISTRY ?= codeclimate
-RELEASE_TAG ?= latest
+
+ifndef RELEASE_TAG
+override RELEASE_TAG = latest
+endif
 
 image:
 	docker build --rm -t $(IMAGE_NAME) .


### PR DESCRIPTION
Deprecate pushing of the image to GCR in favor of pushing to Dockerhub.